### PR TITLE
application.rbで環境設定(不要なファイルを作らないように)

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -20,5 +20,13 @@ module RailsMediaSharingApp
     # config.eager_load_paths << Rails.root.join("extras")
     # Set the default time zone
     config.time_zone = 'Tokyo'
+    
+    config.generators do |g|
+      g.jbuilder false
+      g.javascripts false
+      g.stylesheets false
+      g.helper false
+      g.test_framework false
+    end
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -20,7 +20,6 @@ module RailsMediaSharingApp
     # config.eager_load_paths << Rails.root.join("extras")
     # Set the default time zone
     config.time_zone = 'Tokyo'
-    
     config.generators do |g|
       g.jbuilder false
       g.javascripts false


### PR DESCRIPTION
### issue

https://github.com/Hashimoto-Noriaki/rails_media_sharing_app/issues/19#issue-2393621528

### 変更点
- https://github.com/Hashimoto-Noriaki/rails_media_sharing_app/issues/19#issue-2393621528

### 補足
config/application.rb に config.api_only = trueは今回は記述しない。
現在はAPI開発ではなく、generate コマンドを実行した際に View ファイルが作られなくなってしまうから。

### GitHubActionsでチェック

<img width="1440" alt="スクリーンショット 2024-07-07 11 45 24" src="https://github.com/Hashimoto-Noriaki/rails_media_sharing_app/assets/73786052/73d7be3c-fb6f-4f9e-86fc-346ff7324d96">

<img width="1242" alt="スクリーンショット 2024-07-07 11 46 12" src="https://github.com/Hashimoto-Noriaki/rails_media_sharing_app/assets/73786052/64b67763-be3e-46b7-a345-707898d3dde6">

