### PR TITLE
Railsアプリの国際化(I18n)日本語化とデフォルトのタイムゾーンを日本に再設定

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,8 @@ gem 'bootsnap', require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
+gem 'rails-i18n'
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem 'debug', platforms: %i[mri mingw x64_mingw]

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -187,6 +187,9 @@ GEM
     rails-html-sanitizer (1.6.0)
       loofah (~> 2.21)
       nokogiri (~> 1.14)
+    rails-i18n (7.0.9)
+      i18n (>= 0.7, < 2)
+      railties (>= 6.0.0, < 8)
     railties (7.0.8.4)
       actionpack (= 7.0.8.4)
       activesupport (= 7.0.8.4)
@@ -306,6 +309,7 @@ DEPENDENCIES
   pry-rails
   puma (~> 5.0)
   rails (~> 7.0.4, >= 7.0.4.3)
+  rails-i18n
   rspec-rails
   rubocop
   rubocop-performance

--- a/config/application.rb
+++ b/config/application.rb
@@ -10,16 +10,9 @@ module RailsMediaSharingApp
   class Application < Rails::Application
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 7.0
-
+    config.time_zone = 'Asia/Tokyo'
+    config.i18n.default_locale = :ja
     # Configuration for the application, engines, and railties goes here.
-    #
-    # These settings can be overridden in specific environments using the files
-    # in config/environments, which are processed later.
-    #
-    # config.time_zone = "Central Time (US & Canada)"
-    # config.eager_load_paths << Rails.root.join("extras")
-    # Set the default time zone
-    config.time_zone = 'Tokyo'
     config.generators do |g|
       g.jbuilder false
       g.javascripts false

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -1,0 +1,4 @@
+ja:
+  users_controller:
+    email_already_registered: 'このメールアドレスはすでに登録されています。'
+    user_created_successfully: 'ユーザーが正常に登録されました。'


### PR DESCRIPTION
### issue
https://github.com/Hashimoto-Noriaki/rails_media_sharing_app/issues/26#issue-2393879402

### 変更点
- Gemfile
- Gemfile.lock
- config/application.rb
- config/locales/ja.yml

### この後のissue
config/locales/ja.ymlは以下の新規登録で実装するための設定

https://github.com/Hashimoto-Noriaki/rails_media_sharing_app/pull/34#issue-2406895239

### 参考記事

https://qiita.com/shimadama/items/7e5c3d75c9a9f51abdd5#%E7%9B%AE%E7%9A%84

### GitHubActions

<img width="1440" alt="スクリーンショット 2024-07-13 23 21 21" src="https://github.com/user-attachments/assets/c90a111c-421c-423e-8ed6-f3268caa3739">

