### PR TITLE
Userモデルのバリデーションテスト

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -78,3 +78,7 @@ Style/FrozenStringLiteralComment:
 # 標準ストリームのグローバル変数を許可する
 Style/GlobalStdStream:
   Enabled: false
+
+#contextの説明が特定の形式である必要がないようにする
+RSpec/ContextWording:
+  Enabled: false

--- a/spec/factories/user.rb
+++ b/spec/factories/user.rb
@@ -1,0 +1,8 @@
+FactoryBot.define do
+  factory :user do
+    name { Faker::Name.name }
+    email { Faker::Internet.unique.email }
+    password { 'password' }
+    password_confirmation { 'password' }
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,79 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  context '必要な情報が全て揃っている時' do
+    let(:user) { build(:user) }
+
+    it 'ユーザー登録が成功する' do
+      expect(user).to be_valid
+    end
+  end
+
+  context '名前だけが入力された時' do
+    let(:user) { build(:user, email: nil, password: nil) }
+
+    it 'エラーが発生する' do
+      expect(user).not_to be_valid
+    end
+  end
+
+  context 'メールアドレスが入力されていない時' do
+    let(:user) { build(:user, email: nil) }
+
+    it 'エラーが発生する' do
+      expect(user).not_to be_valid
+    end
+  end
+
+  context 'パスワードが入力されていない時' do
+    let(:user) { build(:user, password: nil) }
+
+    it 'エラーが発生する' do
+      expect(user).not_to be_valid
+    end
+  end
+
+  context 'パスワードの確認が一致しない時' do
+    let(:user) { build(:user, password: 'password', password_confirmation: 'different_password') }
+
+    it 'エラーが発生する' do
+      expect(user).not_to be_valid
+    end
+  end
+
+  context '名前が255文字を超える時' do
+    let(:user) { build(:user, name: 'a' * 256) }
+
+    it 'エラーが発生する' do
+      expect(user).not_to be_valid
+    end
+  end
+
+  context '重複したメールアドレスがある時' do
+    before do
+      create(:user, email: 'unique@example.com')
+    end
+
+    let(:user) { build(:user, email: 'unique@example.com') }
+
+    it 'エラーが発生する' do
+      expect(user).not_to be_valid
+    end
+  end
+
+  context 'メールアドレスの形式が不正な時' do
+    let(:user) { build(:user, email: 'invalid-email') }
+
+    it 'エラーが発生する' do
+      expect(user).not_to be_valid
+    end
+  end
+
+  context 'パスワードが8文字未満の時' do
+    let(:user) { build(:user, password: 'a' * 7) }
+
+    it 'エラーが発生する' do
+      expect(user).not_to be_valid
+    end
+  end
+end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -89,4 +89,7 @@ RSpec.configure do |config|
   #   # test failures related to randomization by passing the same `--seed` value
   #   # as the one that triggered the failure.
   #   # Kernel.srand config.seed
+  config.before(:all) do
+    FactoryBot.reload
+  end
 end


### PR DESCRIPTION
### 変更点
- .rubocop.yml(contextの規約を解消)
- spec/models/user.rb
- spec/spec_helper.rb
- spec/factories/user.rb

### 参考資料
・trait
https://qiita.com/Hashimoto-Noriaki/items/fb047ad54be4a4403eb6

・KeyError: Factory not registered: "user"のエラー
https://qiita.com/H-Iida/items/8132d1cd493d0c4e85a0

### 動作確認

<img width="1097" alt="スクリーンショット 2024-09-05 3 42 52" src="https://github.com/user-attachments/assets/1e240d33-bc54-4f4a-b16e-b903e41ae7dd">

